### PR TITLE
Don't default to -v

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ func NewWbsDefaultConfig() *WbsConfig {
 		BuildTargetName:          "server",
 		BuildCommand:             "go",
 		BuildOptions:             []string{"build", "-v"},
-		StartOptions:             []string{"-v"},
+		StartOptions:             []string{},
 		WatchFileExt:             []string{".go", ".tmpl", ".html"},
 		WatchFileExcludePatterns: []string{"*_gen.go"},
 		WatchTargetDirs:          []string{"."},


### PR DESCRIPTION
Defaulting to using `program -v` causes the built in go flags module to spit out `00:02:28 runner      | flag provided but not defined: -v` along with the command help if there's no -v flag defined instead of running.

(Discovered, reproducible with http://github.com/arkie/indigo/)
