### PR TITLE
Fixed issue with log output.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +36,7 @@ func (b *WbsBuilder) Build() error {
 		return err
 	}
 
-	builderLog("starting build: %s %s", evaledCommand, evaledOptions)
+	builderLog(fmt.Sprintf("starting build: %s %s", evaledCommand, evaledOptions))
 	createBuildTargetDir(evaledTargetDir[0])
 	cmd := exec.Command(evaledCommand[0], evaledOptions...)
 	out, err := cmd.CombinedOutput()

--- a/logger.go
+++ b/logger.go
@@ -12,12 +12,12 @@ type logFunc func(string, ...interface{})
 var logger = log.New(os.Stderr, "", 0)
 
 // NewLogFunc create log func
-func NewLogFunc(prefix string) func(string, ...interface{}) {
+func NewLogFunc(prefix string) func(string) {
 	prefix = fmt.Sprintf("%-11s", prefix)
-	return func(format string, v ...interface{}) {
+	return func(message string) {
 		now := time.Now()
 		timeString := now.Format("15:04:05")
-		format = fmt.Sprintf("%s %s | %s", timeString, prefix, format)
-		logger.Printf(format, v...)
+		message = fmt.Sprintf("%s %s | ", timeString, prefix) + message
+		logger.Print(message)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"gopkg.in/fsnotify.v1"
@@ -28,7 +29,7 @@ func main() {
 	if *configFile != "" {
 		config, err = NewWbsConfig(*configFile)
 		if err != nil {
-			mainLogger("failed to create config: %s", err)
+			mainLogger(fmt.Sprintf("failed to create config: %s", err))
 			os.Exit(1)
 		}
 	} else {
@@ -37,27 +38,27 @@ func main() {
 
 	watcher, err := NewWbsWatcher(config)
 	if err != nil {
-		mainLogger("failed to initialize watcher: %s", err)
+		mainLogger(fmt.Sprintf("failed to initialize watcher: %s", err))
 		os.Exit(1)
 	}
 	runner, err := NewWbsRunner(config)
 	if err != nil {
-		mainLogger("failed to initialize runner: %s", err)
+		mainLogger(fmt.Sprintf("failed to initialize runner: %s", err))
 		os.Exit(1)
 	}
 	builder, err := NewWbsBuilder(config)
 	if err != nil {
-		mainLogger("failed to initialize builder: %s", err)
+		mainLogger(fmt.Sprintf("failed to initialize builder: %s", err))
 		os.Exit(1)
 	}
 
 	if err := builder.Build(); err != nil {
-		mainLogger("failed to build: %s", err)
+		mainLogger(fmt.Sprintf("failed to build: %s", err))
 		os.Exit(1)
 	}
 	err = runner.Serve()
 	if err != nil {
-		mainLogger("failed to start server: %s", err)
+		mainLogger(fmt.Sprintf("failed to start server: %s", err))
 		os.Exit(1)
 	}
 	defer runner.Stop()
@@ -69,7 +70,7 @@ func main() {
 			case event := <-watcher.w.Events:
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					e := event.String()
-					mainLogger("file modified: %s", e)
+					mainLogger(fmt.Sprintf("file modified: %s", e))
 					if config.RestartProcess {
 						runner.Stop()
 					}
@@ -77,7 +78,7 @@ func main() {
 					runner.Serve()
 				}
 			case err := <-watcher.w.Errors:
-				mainLogger("error: %s", err)
+				mainLogger(fmt.Sprintf("error: %s", err))
 			}
 		}
 	}()

--- a/runner.go
+++ b/runner.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -31,7 +32,7 @@ func (r *WbsRunner) Serve() error {
 	if err != nil {
 		return err
 	}
-	runnerLog("starting server: %s %s", evaledCommand, evaledOptions)
+	runnerLog(fmt.Sprintf("starting server: %s %s", evaledCommand, evaledOptions))
 	cmd := exec.Command(evaledCommand[0], evaledOptions...)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -53,13 +54,13 @@ func (r *WbsRunner) Serve() error {
 		return err
 	}
 	r.Pid = cmd.Process.Pid
-	runnerLog("server started: PID %d", r.Pid)
+	runnerLog(fmt.Sprintf("server started: PID %d", r.Pid))
 	return nil
 }
 
 // Stop stops running process
 func (r *WbsRunner) Stop() error {
-	runnerLog("stopping server: PID %d", r.Pid)
+	runnerLog(fmt.Sprintf("stopping server: PID %d", r.Pid))
 	p, err := os.FindProcess(r.Pid)
 	if err != nil {
 		runnerLog(err.Error())
@@ -69,7 +70,7 @@ func (r *WbsRunner) Stop() error {
 		runnerLog(err.Error())
 		return err
 	}
-	runnerLog("server stopped: PID %d", r.Pid)
+	runnerLog(fmt.Sprintf("server stopped: PID %d", r.Pid))
 	return nil
 }
 

--- a/watcher.go
+++ b/watcher.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/fsnotify.v1"
 
+	"fmt"
 	"path/filepath"
 )
 
@@ -66,10 +67,10 @@ func (w *WbsWatcher) initWatcher() {
 			}
 			fileExt := filepath.Ext(path)
 			if contains(fileExt, w.TargetFileExt) && !matchContains(path, w.ExcludeFilePatterns) {
-				watcherLog("start watching %s", path)
+				watcherLog(fmt.Sprintf("start watching %s", path))
 				err := w.w.Add(path)
 				if err != nil {
-					watcherLog("failed to watch file: %s: %s", path, err)
+					watcherLog(fmt.Sprintf("failed to watch file: %s: %s", path, err))
 					return err
 				}
 			}
@@ -83,7 +84,7 @@ func NewWbsWatcher(config *WbsConfig) (*WbsWatcher, error) {
 	var watcher *WbsWatcher
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
-		watcherLog("failed to create watcher: %s", err)
+		watcherLog(fmt.Sprintf("failed to create watcher: %s", err))
 		return watcher, err
 	}
 	watcher = &WbsWatcher{


### PR DESCRIPTION
If log output contained strings that looked like Go formatting strings, then they would be parsed by the wbs logger. This would result in some output being broken, e.g. with valid strings having "%!C(MISSING)" inserted into them in the place of the format-like strings.

The change has made some of the other logging more verbose sadly, and this could more than likely be improved, but for now this does fix the issue.

To reproduce the issue, try print something like `url.QueryEscape("Hello, World")`, and have it put the output through wbs.